### PR TITLE
bugfix: Cookie Auth Vercel

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,12 +14,15 @@ import appointmentsRouter from "./routes/appointments.js";
 
 const app = express();
 const port = process.env.PORT || 5000;
+const env = process.env.NODE_ENV;
+const isProductionLike = env === "production" || env === "staging";
 
 // Middleware
 app.use(express.json());
 const allowedOrigins = [
-  "http://localhost:5174",
+  "http://localhost:5173",
   "https://staging-healthease.vercel.app",
+  "https://healthease-frontend.vercel.app"
 ];
 
 app.use(
@@ -171,14 +174,14 @@ app.post("/login", async (req, res) => {
 
     res.cookie("accessToken", accessToken, {
       httpOnly: true,
-      secure: false,
+      secure: isProductionLike,
       sameSite: "lax",
       maxAge: 15 * 60 * 1000,
     });
 
     res.cookie("refreshToken", refreshToken, {
       httpOnly: true,
-      secure: false,
+      secure: isProductionLike,
       sameSite: "lax",
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
@@ -207,7 +210,7 @@ app.post("/refresh", (req, res) => {
 
     res.cookie("accessToken", newAccessToken, {
       httpOnly: true,
-      secure: false,
+      secure: isProductionLike,
       sameSite: "lax",
       maxAge: 15 * 60 * 1000,
     });


### PR DESCRIPTION
## Summary

This MR fixes a bug where users would get logged out on page refresh when using the staging environment deployed on Vercel.

## Root Cause

The issue was caused by cookies not being set correctly in production-like environments due to the `secure` flag not being enabled. Browsers ignore cookies with the `Secure` flag over non-HTTPS connections — this caused authentication tokens to not persist across page loads.

## Fix

- Introduced an `isProductionLike` flag to handle both `production` and `staging` environments.
- Applied this flag to the `secure` option in `res.cookie()` for access and refresh tokens.
- Updated CORS `allowedOrigins` to include staging and prod frontend URLs explicitly.

## How to test

1. Deploy this branch to staging.
2. Log in via the frontend (`staging-healthease.vercel.app`).
3. Refresh the page — user should remain authenticated.
4. Access protected routes — should work as expected.

## Notes

This fix maintains `secure: false` in local development for convenience.
